### PR TITLE
feat(image-format): possibility to change image format

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Default value: `''`
 
 A string value that is used to do change path of generated style files relative to base images path.
 
+#### options.imageFormat
+Type: `String`
+Default value: `'png'`
+
+A string value that is used for getting images in specified format and generate sprite in it.
+
 ### Usage Examples
 
 ### Basic Usage

--- a/tasks/autospritesmith.js
+++ b/tasks/autospritesmith.js
@@ -38,8 +38,8 @@ module.exports = function(grunt) {
 
     target = _.merge(options.sprite, target);
 
-    target.src = path.join( dir, '*.png');
-    target.dest = path.join( dir, options.destPathMap || 'sprite', spriteName + '.png');
+    target.src = path.join( dir, '*.' + options.imageFormat);
+    target.dest = path.join( dir, options.destPathMap || 'sprite', spriteName + '.' + options.imageFormat);
     target.destCss = path.join( dir, options.destCssPathMap || 'sprite', spriteName + '.' + target.cssFormat );
 
     conf[targetName] = target;
@@ -51,7 +51,8 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('autospritesmith', 'The best Grunt plugin ever.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
-      sprite:defaultSpriteSmithConf
+      sprite:defaultSpriteSmithConf,
+      imageFormat: 'png'
     });
 
     var target = this.target;


### PR DESCRIPTION
First of all thanks for this plugin.

Only thing missing here is possibility to generate sprites other than PNG. Spritesmith allows for creation e.g. JPG sprites.

This PR, while leaving defaults as before, allows changing image format to create sprites in different format.
